### PR TITLE
Improved performance of `createinitialrevisions` management command

### DIFF
--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -2,7 +2,6 @@ import json
 
 from django.apps import apps
 from django.core.management import CommandError
-from django.conf import settings
 from django.db import connections, reset_queries, transaction, router
 from reversion.models import Revision, Version, _safe_subquery
 from reversion.management.commands import BaseRevisionCommand

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -70,26 +70,25 @@ class Command(BaseRevisionCommand):
                     ),
                     "object_id",
                 )
+                live_objs = live_objs.order_by()
                 # Save all the versions.
-                ids = list(live_objs.values_list("pk", flat=True).order_by())
-                total = len(ids)
-                for i in range(0, total, batch_size):
-                    chunked_ids = ids[i:i+batch_size]
-                    objects = live_objs.in_bulk(chunked_ids)
-                    for obj in objects.values():
-                        with create_revision(using=using):
-                            if meta:
-                                for model, values in zip(meta_models, meta_values):
-                                    add_meta(model, **values)
-                            set_comment(comment)
-                            add_to_revision(obj, model_db=model_db)
-                        created_count += 1
-                    reset_queries()
-                    if verbosity >= 2:
-                        self.stdout.write("- Created {created_count} / {total}".format(
-                            created_count=created_count,
-                            total=total,
-                        ))
+                total = live_objs.count()
+                for obj in live_objs.iterator(batch_size):
+                    with create_revision(using=using):
+                        if meta:
+                            for model, values in zip(meta_models, meta_values):
+                                add_meta(model, **values)
+                        set_comment(comment)
+                        add_to_revision(obj, model_db=model_db)
+                    created_count += 1
+                    # Print out a message every batch_size if feeling extra verbose
+                    if not created_count % batch_size:
+                        reset_queries()
+                        if verbosity >= 2:
+                            self.stdout.write("- Created {created_count} / {total}".format(
+                                created_count=created_count,
+                                total=total,
+                            ))
                 # Print out a message, if feeling verbose.
                 if verbosity >= 1:
                     self.stdout.write("- Created {total} / {total}".format(

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -76,7 +76,6 @@ class Command(BaseRevisionCommand):
                 live_objs = live_objs.order_by()
                 # Save all the versions.
                 if use_iterator:
-                    print("USING ITERATOR")
                     total = live_objs.count()
                     if total:
                         for obj in live_objs.iterator(batch_size):

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -73,22 +73,23 @@ class Command(BaseRevisionCommand):
                 live_objs = live_objs.order_by()
                 # Save all the versions.
                 total = live_objs.count()
-                for obj in live_objs.iterator(batch_size):
-                    with create_revision(using=using):
-                        if meta:
-                            for model, values in zip(meta_models, meta_values):
-                                add_meta(model, **values)
-                        set_comment(comment)
-                        add_to_revision(obj, model_db=model_db)
-                    created_count += 1
-                    # Print out a message every batch_size if feeling extra verbose
-                    if not created_count % batch_size:
-                        reset_queries()
-                        if verbosity >= 2:
-                            self.stdout.write("- Created {created_count} / {total}".format(
-                                created_count=created_count,
-                                total=total,
-                            ))
+                if total:
+                    for obj in live_objs.iterator(batch_size):
+                        with create_revision(using=using):
+                            if meta:
+                                for model, values in zip(meta_models, meta_values):
+                                    add_meta(model, **values)
+                            set_comment(comment)
+                            add_to_revision(obj, model_db=model_db)
+                        created_count += 1
+                        # Print out a message every batch_size if feeling extra verbose
+                        if not created_count % batch_size:
+                            reset_queries()
+                            if verbosity >= 2:
+                                self.stdout.write("- Created {created_count} / {total}".format(
+                                    created_count=created_count,
+                                    total=total,
+                                ))
                 # Print out a message, if feeling verbose.
                 if verbosity >= 1:
                     self.stdout.write("- Created {total} / {total}".format(

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -76,6 +76,7 @@ class Command(BaseRevisionCommand):
                 live_objs = live_objs.order_by()
                 # Save all the versions.
                 if use_iterator:
+                    print("USING ITERATOR")
                     total = live_objs.count()
                     if total:
                         for obj in live_objs.iterator(batch_size):

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -53,7 +53,8 @@ class Command(BaseRevisionCommand):
         meta_values = meta.values()
         # Determine if we should use queryset.iterator()
         using = using or router.db_for_write(Revision)
-        use_iterator = connections[using].vendor in ("postgresql",) and not settings.DISABLE_SERVER_SIDE_CURSORS
+        server_side_cursors = not connections[using].settings_dict.get('DISABLE_SERVER_SIDE_CURSORS')
+        use_iterator = connections[using].vendor in ("postgresql",) and server_side_cursors
         # Create revisions.
         with transaction.atomic(using=using):
             for model in self.get_models(options):

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -102,7 +102,7 @@ class Command(BaseRevisionCommand):
                     self.stdout.write("- Created {total} / {total}".format(
                         total=total,
                     ))
-                    
+
     def create_revision(self, obj, using, meta, meta_models, meta_values, comment, model_db):
         with create_revision(using=using):
             if meta:
@@ -110,7 +110,7 @@ class Command(BaseRevisionCommand):
                     add_meta(model, **values)
             set_comment(comment)
             add_to_revision(obj, model_db=model_db)
-            
+
     def batch_complete(self, verbosity, created_count, total):
         reset_queries()
         if verbosity >= 2:
@@ -118,4 +118,3 @@ class Command(BaseRevisionCommand):
                 created_count=created_count,
                 total=total,
             ))
-            

--- a/reversion/management/commands/createinitialrevisions.py
+++ b/reversion/management/commands/createinitialrevisions.py
@@ -2,7 +2,8 @@ import json
 
 from django.apps import apps
 from django.core.management import CommandError
-from django.db import reset_queries, transaction, router
+from django.conf import settings
+from django.db import connections, reset_queries, transaction, router
 from reversion.models import Revision, Version, _safe_subquery
 from reversion.management.commands import BaseRevisionCommand
 from reversion.revisions import create_revision, set_comment, add_to_revision, add_meta
@@ -50,8 +51,10 @@ class Command(BaseRevisionCommand):
             except LookupError:
                 raise CommandError("Unknown model: {}".format(label))
         meta_values = meta.values()
-        # Create revisions.
+        # Determine if we should use queryset.iterator()
         using = using or router.db_for_write(Revision)
+        use_iterator = connections[using].vendor in ("postgresql",) and not settings.DISABLE_SERVER_SIDE_CURSORS
+        # Create revisions.
         with transaction.atomic(using=using):
             for model in self.get_models(options):
                 # Check all models for empty revisions.
@@ -72,26 +75,47 @@ class Command(BaseRevisionCommand):
                 )
                 live_objs = live_objs.order_by()
                 # Save all the versions.
-                total = live_objs.count()
-                if total:
-                    for obj in live_objs.iterator(batch_size):
-                        with create_revision(using=using):
-                            if meta:
-                                for model, values in zip(meta_models, meta_values):
-                                    add_meta(model, **values)
-                            set_comment(comment)
-                            add_to_revision(obj, model_db=model_db)
-                        created_count += 1
+                if use_iterator:
+                    total = live_objs.count()
+                    if total:
+                        for obj in live_objs.iterator(batch_size):
+                            self.create_revision(obj, using, meta, meta_models, meta_values, comment, model_db)
+                            created_count += 1
+                            # Print out a message every batch_size if feeling extra verbose
+                            if not created_count % batch_size:
+                                self.batch_complete(verbosity, created_count, total)
+                else:
+                    # Save all the versions.
+                    ids = list(live_objs.values_list("pk", flat=True))
+                    total = len(ids)
+                    for i in range(0, total, batch_size):
+                        chunked_ids = ids[i:i+batch_size]
+                        objects = live_objs.in_bulk(chunked_ids)
+                        for obj in objects.values():
+                            self.create_revision(obj, using, meta, meta_models, meta_values, comment, model_db)
+                            created_count += 1
                         # Print out a message every batch_size if feeling extra verbose
-                        if not created_count % batch_size:
-                            reset_queries()
-                            if verbosity >= 2:
-                                self.stdout.write("- Created {created_count} / {total}".format(
-                                    created_count=created_count,
-                                    total=total,
-                                ))
+                        self.batch_complete(verbosity, created_count, total)
+
                 # Print out a message, if feeling verbose.
                 if verbosity >= 1:
                     self.stdout.write("- Created {total} / {total}".format(
                         total=total,
                     ))
+                    
+    def create_revision(self, obj, using, meta, meta_models, meta_values, comment, model_db):
+        with create_revision(using=using):
+            if meta:
+                for model, values in zip(meta_models, meta_values):
+                    add_meta(model, **values)
+            set_comment(comment)
+            add_to_revision(obj, model_db=model_db)
+            
+    def batch_complete(self, verbosity, created_count, total):
+        reset_queries()
+        if verbosity >= 2:
+            self.stdout.write("- Created {created_count} / {total}".format(
+                created_count=created_count,
+                total=total,
+            ))
+            


### PR DESCRIPTION
Rather than retrieving the list of PKs that needs revisions created for, and then pulling out the actual objects in separate queries using `in_bulk`, we drop it down to a single `count()` query (to get the total number) and an `iterator()` query. This improves the performance (and possibly memory usage) on postgres databases when server side cursors are enabled (which they are by default on postgres databases).